### PR TITLE
Adds a warning exception class and looks for the warning prefix

### DIFF
--- a/Connection.php
+++ b/Connection.php
@@ -288,6 +288,11 @@ class Rserve_Connection {
 		if( !$r['is_error'] ) {
 				return $this->parseResponse($r['contents'], $parser);
 		}
+
+		if(strpos($r['contents'], "R warning:") == 0) {
+				throw new Rserve_Warning($r);
+		}
+
 		throw new Rserve_Exception('unable to evaluate', $r);
 	}
 
@@ -576,6 +581,9 @@ class Rserve_Exception extends Exception {
 }
 
 class Rserve_Parser_Exception extends Rserve_Exception {
+}
+
+class Rserve_Warning extends Rserve_Exception {
 }
 
 Rserve_Connection::init();


### PR DESCRIPTION
In order to differentiate errors from warnings I created a warning exception class. From what I have research with R there is no real way to return a warning and halt execution of the R script. You either call `stop()` which returns an error, `return()` which returns a non-error, or override `warning()` to either throw an error or non-error. My stupid work around is to have a prefix in the error message, in this case `R warning`, so that we can differentiate errors from warnings and halt execution.